### PR TITLE
Changes to support multiple file_versions

### DIFF
--- a/techmd_dump/dump_dao_techmd.rb
+++ b/techmd_dump/dump_dao_techmd.rb
@@ -38,7 +38,7 @@ do_component_uris.flatten.each do |uri|
   do_component_id = do_component["uri"].split('/').last
   do_id = do_component["digital_object"]["ref"].split('/').last
 
-  file_version = do_component["file_versions"].select { |file_version| file_version["use_statement"] == "archive image" }[0]
+  file_version = do_component["file_versions"].select { |file_version| file_version["use_statement"] == "master" }[0]
   file_uri = file_version["file_uri"]
   file_size_bytes = file_version["file_size_bytes"]
   checksum = file_version["checksum"]

--- a/techmd_dump/dump_dao_techmd.rb
+++ b/techmd_dump/dump_dao_techmd.rb
@@ -38,7 +38,7 @@ do_component_uris.flatten.each do |uri|
   do_component_id = do_component["uri"].split('/').last
   do_id = do_component["digital_object"]["ref"].split('/').last
 
-  file_version = do_component["file_versions"].select { |file_version| file_version["use_statement"] = "archive image" }[0]
+  file_version = do_component["file_versions"].select { |file_version| file_version["use_statement"] == "archive image" }[0]
   file_uri = file_version["file_uri"]
   file_size_bytes = file_version["file_size_bytes"]
   checksum = file_version["checksum"]


### PR DESCRIPTION
### What does this PR do?
Fixes a typo and updates the use statement for master files in the dump_dao_techmd.rb script.

### Motivation and context
These changes are necessary for techmd extraction to work on DO components with multiple file_versions. Previously, the script did not properly check for the master file.

### How has this been tested?
I ran the script on the Japanese prints collection. After the changes, it captured the technical metadata from the correct file_versions.

### How can a reviewer see the effects of these changes?
1. Pull the dev branch of the repo
2. Create config.yml with the necessary params
3. Run export_dao_ids.rb on a collection with techmd and multiple file_versions per DO component
4. Run dump_dao_techmd.rb on the output of export_dao_ids.rb

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
