### PR TITLE
Update fits-to-json.xsl

### DIFF
--- a/batch_dao/fits-to-json.xsl
+++ b/batch_dao/fits-to-json.xsl
@@ -88,8 +88,8 @@
         <xsl:text>"checksum":"</xsl:text><xsl:value-of select="fits:fileinfo/fits:md5checksum"/><xsl:text>",</xsl:text>
         <xsl:text>"bitDepth":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:track[@type='video']/fits:bitDepth"/><xsl:text>",</xsl:text>
         <xsl:text>"colorSpace":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:track[@type='video']/fits:colorspace"/><xsl:text>",</xsl:text>
-        <xsl:text>"duration-Ms":"</xsl:text><xsl:value-of select="fits:metadata/fits:audio/fits:duration"/><xsl:text>",</xsl:text>
-        <xsl:text>"bitRate":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:bitrate"/><xsl:text>",</xsl:text>
+        <xsl:text>"duration-Ms":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:track[@type='video']/fits:duration"/><xsl:text>",</xsl:text>
+        <xsl:text>"bitRate":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:track[@type='video']/fits:bitRate"/><xsl:text>",</xsl:text>
         <xsl:text>"frameRate":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:track[@type='video']/fits:frameRate"/><xsl:text>",</xsl:text>
         <xsl:text>"chromaSubsampling":"</xsl:text><xsl:value-of select="fits:metadata/fits:video/fits:track[@type='video']/fits:chromaSubsampling"/><xsl:text>"}]</xsl:text>
     </xsl:template>


### PR DESCRIPTION
fix paths for duration and bitRate in .mov template

<!--- Provide a general summary of your changes in the title above -->
     Changed two lines of fits to json xsl in the .mov template
### What does this PR do?
<!--- Describe your changes -->
   fixes bad XPaths that were causing blank values in the JSON
### Motivation and context
<!--- If necessary, describe why is this change required. What problem does it solve? -->
   this caused bitrate and duration for .mov files to fail to import into ASpace, leaving some collections lacking techMD
### How has this been tested?
<!--- Describe in detail how you tested your changes -->
    I reran this over a FITS file to see if it generated JSON with the fields correctly populated
### How can a reviewer see the effects of these changes?
<!-- Describe how the person reviewing this PR can manually see the changes -->
   Run the XSL over a FITS file that contains information on .mov files. 
### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ X] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have stakeholder approval to make this change.
