### PR TITLE
Comment out general note TechMD function; revert DAO compontent labels to being identical with titles

### DIFF
--- a/batch_dao/aspace_batch_dao.py
+++ b/batch_dao/aspace_batch_dao.py
@@ -129,8 +129,7 @@ def main():
             base_name = name[0:period_loc]
             dig_obj = {'jsonmodel_type': 'digital_object_component', 'publish': False, 'label': lab_val,
                         'file_versions':build_comp_file_version(name, tech_data), 'title': base_name,
-                        'display_string': name, 'notes': build_comp_exif_notes(name, tech_data),
-                        'digital_object': {'ref': dig_obj_uri}}
+                        'display_string': name, 'digital_object': {'ref': dig_obj_uri}}
             dig_obj_data = json.dumps(dig_obj)
             print(dig_obj_data)
             # Post the digital object component
@@ -322,94 +321,96 @@ def get_format_enum(fits):
 # builds the notes section for the digital object component where techMD that can't live on the file version is stored.
 # not all components have all metadata, try-catch blocks are needed to prevent key errors. Value > 0 tests are required
 # because Aspace won't consider JSON valid if it contains an 'empty' note field.
-def build_comp_exif_notes(filename, techmd_dict):
-    note_list = []
-    try:
-        if len(techmd_dict[filename]['duration-Ms']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['duration-Ms'], 'duration Ms'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['duration-H:M:S']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['duration-H:M:S'], 'duration H:M:S'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['sampleRate']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['sampleRate'], 'sample rate'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['bitDepth']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['bitDepth'], 'bit depth'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['pixelDimensions']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['pixelDimensions'], 'pixel dimensions'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['resolution']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['resolution'], 'resolution'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['bitsPerSample']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['bitsPerSample'], 'bits per sample'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['colorSpace']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['colorSpace'], 'color space'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['createDate']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['createDate'], 'create date'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['creatingApplicationName']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['creatingApplicationName'], 'creating application name'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['creatingApplicationVersion']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['creatingApplicationVersion'], 'creating application version'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['author']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['author'], 'author'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['title']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['title'], 'title'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['duration-Ms']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['duration-Ms'], 'duration-Ms'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['bitRate']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['bitRate'], 'bit rate'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['frameRate']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['frameRate'], 'frame rate'))
-    except KeyError:
-        pass
-    try:
-        if len(techmd_dict[filename]['chromaSubsampling']) > 0:
-            note_list.append(note_builder(techmd_dict[filename]['chromaSubsampling'], 'chroma subsampling'))
-    except KeyError:
-        pass
-    return note_list
+# This function is currently commented out b/c decision was made not to store techMD in general notes. To re-enable,
+# call from within 'dig_obj' variable definition at ~ line 130
+#def build_comp_exif_notes(filename, techmd_dict):
+    #note_list = []
+    #try:
+        #if len(techmd_dict[filename]['duration-Ms']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['duration-Ms'], 'duration Ms'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['duration-H:M:S']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['duration-H:M:S'], 'duration H:M:S'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['sampleRate']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['sampleRate'], 'sample rate'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['bitDepth']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['bitDepth'], 'bit depth'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['pixelDimensions']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['pixelDimensions'], 'pixel dimensions'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['resolution']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['resolution'], 'resolution'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['bitsPerSample']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['bitsPerSample'], 'bits per sample'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['colorSpace']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['colorSpace'], 'color space'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['createDate']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['createDate'], 'create date'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['creatingApplicationName']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['creatingApplicationName'], 'creating application name'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['creatingApplicationVersion']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['creatingApplicationVersion'], 'creating application version'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['author']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['author'], 'author'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['title']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['title'], 'title'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['duration-Ms']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['duration-Ms'], 'duration-Ms'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['bitRate']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['bitRate'], 'bit rate'))
+    #except KeyError:
+        #pass
+    #try:
+        #if len(techmd_dict[filename]['frameRate']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['frameRate'], 'frame rate'))
+    #except KeyError:
+       # pass
+    #try:
+        #if len(techmd_dict[filename]['chromaSubsampling']) > 0:
+            #note_list.append(note_builder(techmd_dict[filename]['chromaSubsampling'], 'chroma subsampling'))
+    #except KeyError:
+        #pass
+    #return note_list
 
 
 def note_builder(list_index, label_value):

--- a/batch_dao/aspace_batch_dao.py
+++ b/batch_dao/aspace_batch_dao.py
@@ -120,14 +120,9 @@ def main():
         file_names = files_listing[unique_id]
         file_names.sort()
         for name in file_names:
-            lab_val = "Master"
-            if "INT" in name:
-                lab_val = "Intermediate"
-            elif "ACC" in name:
-                lab_val = "Access"
             period_loc = name.index('.')
             base_name = name[0:period_loc]
-            dig_obj = {'jsonmodel_type': 'digital_object_component', 'publish': False, 'label': lab_val,
+            dig_obj = {'jsonmodel_type': 'digital_object_component', 'publish': False, 'label': base_name,
                         'file_versions':build_comp_file_version(name, tech_data), 'title': base_name,
                         'display_string': name, 'digital_object': {'ref': dig_obj_uri}}
             dig_obj_data = json.dumps(dig_obj)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
<!--- Describe your changes -->
Comments out the function which builds General Notes for DAO components to hold TechMD. Leave instructions to reinstate code if we change our minds. Also removes changes made for RaR DAOs, which now have a separate branch. In mainline DAO component labels should go back to matching titles.
### Motivation and context
<!--- If necessary, describe why is this change required. What problem does it solve? -->
Both cases essentially revert functionality that was added and then later decided to be undesirable.
### How has this been tested?
<!--- Describe in detail how you tested your changes -->
Used the new version of the code to build a DAO for a recently imaged collection.
### How can a reviewer see the effects of these changes?
<!-- Describe how the person reviewing this PR can manually see the changes -->
Build a DAO and check the components - pre-PR will have labels that say "master" and several types of technical metadata stored in general notes fields.
### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [X ] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have stakeholder approval to make this change.
