### PR TITLE
Rework structure to cope with varying description levels

### DIFF
--- a/batch_dao/aspace_ead_to_tab.xsl
+++ b/batch_dao/aspace_ead_to_tab.xsl
@@ -7,7 +7,7 @@
     </xsl:variable>
     <!-- Set language code at the start of a project. Should be 3-letter NISO encoding, typically 'eng' or 'zxx' -->
     <xsl:variable name="langCode">
-        <xsl:text>lang code here</xsl:text>
+        <xsl:text>Language</xsl:text>
     </xsl:variable>
     <!-- Set Digital Commonwealth genre type here. Must be one of the 20 headings listed in the DC-BPL MODS guidelines. Word only, Aspace handles the authority code. -->
     <xsl:variable name="DCGenre">
@@ -18,30 +18,31 @@
         <xsl:text>typeOfResource</xsl:text>
     </xsl:variable>
     <xsl:template match="/">
-        <!-- Level attribute needs changing on a project-dependant basis! -->
-        <xsl:for-each select="//ead:c[@level='file']">
-            <xsl:choose>
-                <xsl:when test="ead:did/ead:unitid">
-                    <xsl:value-of select="ead:did/ead:unitid"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="@id"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="@level"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of
-                        select="normalize-space(//ead:ead/ead:archdesc[@level='collection']/ead:userestrict/ead:p)"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="ead:did/ead:unitdate/@normal"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="$langCode"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="$DCGenre"/>
-                    <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="$typeOfResource"/>
-                    <xsl:text>
-</xsl:text>
-                </xsl:when>
-            </xsl:choose>
+        <xsl:for-each select="//ead:did/ead:unitid">
+            <xsl:if test="ancestor::ead:c[@level='file'] or ancestor::ead:c[@level='item']" >
+                <xsl:call-template name="DAO"/>
+            </xsl:if>
         </xsl:for-each>
+    </xsl:template>
+    
+    <xsl:template name="DAO">
+        <xsl:value-of select="."/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of select="ancestor::ead:c[1]/@id"/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of select="ancestor::ead:c[1]/@level"/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of
+            select="normalize-space(//ead:ead/ead:archdesc[@level='collection']/ead:userestrict/ead:p)"/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of select="ead:unitdate/@normal"/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of select="$langCode"/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of select="$DCGenre"/>
+        <xsl:value-of select="$varTab"/>
+        <xsl:value-of select="$typeOfResource"/>
+        <xsl:text>
+</xsl:text>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
<!--- Describe your changes -->
Moves building lines in the tab sheet into a template that can be called based on various different if statements
### Motivation and context
<!--- If necessary, describe why is this change required. What problem does it solve? -->
The original stylesheet processed nodes in a for-each manner at a specific description level (file or item), which had to be changed on a project-dependent basis. We recently processed a collection that had DAOs described at both the file and item level in the same collection, so a way to handle both at once was needed.
### How has this been tested?
<!--- Describe in detail how you tested your changes -->
Ran the new stylesheet over EAD exported from a collection with both file and item level DAOs.
### How can a reviewer see the effects of these changes?
<!-- Describe how the person reviewing this PR can manually see the changes -->
When the previous version is run on an EAD with both file and item level DAOs, it will only output data at one level or the other. This version will put out data on all DAOs in the EAD.
### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ X] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have stakeholder approval to make this change.
