### PR TITLE
fix handling of physical description notes

### DIFF
--- a/archivesspace/stylesheets/as-ead-pdf.xsl
+++ b/archivesspace/stylesheets/as-ead-pdf.xsl
@@ -1728,11 +1728,11 @@
             <!-- <xsl:apply-templates select="ead:origination" mode="dsc"/>  -->          
             <xsl:if test="not(ead:unittitle)">
                 <xsl:value-of select="ead:unitdate"/> 
-            </xsl:if>
-            <xsl:apply-templates select="ead:physdesc" mode="dsc"/>                    
+            </xsl:if>                 
             <xsl:apply-templates select="ead:physloc" mode="dsc"/>    
             <xsl:apply-templates select="ead:dao" mode="dsc"/>            
-            <xsl:apply-templates select="ead:daogrp" mode="dsc"/>            
+            <xsl:apply-templates select="ead:daogrp" mode="dsc"/>   
+            <xsl:apply-templates select="ead:physdesc" mode="dsc"/>   
             <xsl:apply-templates select="ead:langmaterial" mode="dsc"/>            
             <xsl:apply-templates select="ead:materialspec" mode="dsc"/>            
             <xsl:apply-templates select="ead:abstract" mode="dsc"/>             
@@ -1744,11 +1744,6 @@
         (<xsl:apply-templates/>)
     </xsl:template>
     <xsl:template match="ead:unitdate" mode="did"><xsl:apply-templates/></xsl:template>
-    <!-- Formats physical description -->
-    <xsl:template match="ead:physdesc" mode="dsc">
-        <xsl:value-of select="ead:extent[1]"/> (<xsl:value-of select="ead:extent[2]"/>)
-        <xsl:apply-templates/>
-    </xsl:template>
     <!-- Special formatting for elements in the collection inventory list -->
     <xsl:template match="ead:repository | ead:origination[@label='creator'] | ead:unitdate | ead:unitid  
         | ead:physloc | ead:langmaterial | ead:materialspec | ead:container 
@@ -1858,6 +1853,12 @@
         </xsl:when>
         </xsl:choose>
     </xsl:template> 
+    <!-- Formats physical description -->
+    <xsl:template match="ead:physdesc" mode="dsc">
+        <!-- Add header formatting for physdesc notes and move to after DAO block -->
+        <fo:block xsl:use-attribute-sets="h4">Physical Description</fo:block>
+        <xsl:apply-templates/>
+    </xsl:template>
     <!-- Everything else in the dsc -->
     <xsl:template mode="dsc" match="*">
         <xsl:if test="child::*">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Added additional handling for physical description notes and moved their location in the template order.

### Motivation and context
Physical description notes were undifferentiated and illegible in the finding aids. This change was requested by archives as they're going to be using this note more commonly in the future.

### How has this been tested?
Changed stylesheet was uploaded to the test Aspace server, and archivists were invited to print a finding aid and make sure it met their needs.

### How can a reviewer see the effects of these changes?
Swap out the file on the test server and print a finding aid for a collection that contains physical description notes on archival objects.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [X ] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have stakeholder approval to make this change.
