### PR TITLE
change repo variable from global to local

### DIFF
--- a/archivesspace/stylesheets/as-ead-pdf.xsl
+++ b/archivesspace/stylesheets/as-ead-pdf.xsl
@@ -121,11 +121,7 @@
         <xsl:attribute name="border">.5pt solid #ccc</xsl:attribute>
         <xsl:attribute name="border-collapse">seperate</xsl:attribute>
     </xsl:attribute-set>
-    
-   <!-- Variables to change publisher info without changing repository profile -->
-    <xsl:variable name="repo" select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt/ead:titleproper/ead:num"/>
    
-    
     <!--  Start main page design and layout -->
     <xsl:template match="/">
         <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-size="12pt" font-family="serif">
@@ -150,7 +146,7 @@
                     <fo:region-after extent="0.2in"/>
                 </fo:simple-page-master>
             </fo:layout-master-set>
-            <fo:declarations>
+           <fo:declarations>
                 <x:xmpmeta xmlns:x="adobe:ns:meta/">
                     <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
                         <rdf:Description rdf:about=""
@@ -199,7 +195,7 @@
                             <dc:description>
                                 <xsl:value-of select="/ead:ead/ead:archdesc/ead:did/ead:abstract"/>
                             </dc:description>
-                            <!--SUBJECTS-->
+                            <!-- SUBJECTS -->
                             <dc:subject>    
                                 <xsl:for-each select="/ead:ead/ead:archdesc/ead:did/ead:origination/ead:persname">
                                     
@@ -356,6 +352,8 @@
         </fo:block>
     </xsl:template>
     <xsl:template match="ead:publicationstmt" mode="coverPage">
+        <!-- Variables to change publisher info without changing repository profile -->
+        <xsl:variable name="repo" select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt/ead:titleproper/ead:num"/>
         <fo:block margin="0 1in">
             <fo:block>
                 <!-- Commenting out line that pulls publisher info from EAD so that this info can


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
 An update to the Saxon gem used in ArchivesSpace disallows global variables in XSLT files. This update changes a global variable in our finding aid XSL to a local one so that the XSL can continue to run.
### What does this PR do?
<!--- Describe your changes -->
Moved two lines of code so that a variable that was global becomes local
### Motivation and context
<!--- If necessary, describe why is this change required. What problem does it solve? -->
This was necessitated by a bug introduced into Aspace 2.8 that disallows global variables in XSL. Hopefully that bug will be fixed, but changing this variable will allow us to continue to run finding aid exports in the meantime.
### How has this been tested?
<!--- Describe in detail how you tested your changes -->
Uploaded the revised stylesheet to the test server and tried exporting a PDF

### How can a reviewer see the effects of these changes?
<!-- Describe how the person reviewing this PR can manually see the changes -->
Try exporting a PDF from the test server using this version vs. the previous version of the stylesheet.
### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ X] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have stakeholder approval to make this change.
